### PR TITLE
Replace argparse with click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [project]
 name = "dbt-switch"
-version = "0.2.2"
+version = "0.2.3"
 description = "A simple CLI to switch between dbt Cloud projects and hosts."
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
+    "click>=8.1.8",
     "pydantic>=2.10.6",
     "pyyaml>=6.0.2",
 ]
@@ -20,6 +21,9 @@ dev = [
     "pytest-mock>=3.12.0",
     "ruff>=0.12.11",
 ]
+
+[tool.uv]
+package = true
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/dbt_switch/cli/parser.py
+++ b/src/dbt_switch/cli/parser.py
@@ -1,9 +1,8 @@
 """
-Argument parser.
+Argument parser using Click.
 """
 
-import sys
-import argparse
+import click
 
 from dbt_switch.utils import logger, get_current_version
 from dbt_switch.config.file_handler import init_config
@@ -15,68 +14,63 @@ from dbt_switch.config.input_handler import (
     list_projects,
 )
 
-__version__ = get_current_version()
 
-
-def arg_parser():
-    parser = argparse.ArgumentParser(description="dbt Cloud project and host switcher.")
-
-    parser.add_argument("-p", "--project", help="Switch to the specified project")
-
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"%(prog)s {__version__}",
-        help="Show the version number",
-    )
-
-    subparsers = parser.add_subparsers(dest="command", help="Available commands")
-    subparsers.add_parser("init", help="Initialize ~/.dbt/dbt_switch.yml")
-    subparsers.add_parser("add", help="Add a new project host and project_id")
-    subparsers.add_parser("list", help="List all available projects")
-    subparsers.add_parser("delete", help="Delete a project entry")
-
-    update_parser = subparsers.add_parser(
-        "update", help="Update project host or project_id"
-    )
-    update_parser.add_argument(
-        "--host", action="store_true", help="Update project host"
-    )
-    update_parser.add_argument(
-        "--project-id", action="store_true", help="Update project ID"
-    )
-
-    args = parser.parse_args()
-
-    if args.project:
+@click.group(invoke_without_command=True)
+@click.option("-p", "--project", help="Switch to the specified project")
+@click.version_option(version=get_current_version(), prog_name="dbt-switch")
+@click.pass_context
+def cli(ctx, project):
+    """dbt Cloud project and host switcher."""
+    if project:
         try:
-            switch_user_config_input(args.project)
+            switch_user_config_input(project)
         except Exception as e:
-            logger.error(f"Failed to switch to project '{args.project}': {e}")
-            sys.exit(1)
+            logger.error(f"Failed to switch to project '{project}': {e}")
+            ctx.exit(1)
         return
 
-    if not args.command:
-        parser.print_help()
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@cli.command()
+def init():
+    """Initialize ~/.dbt/dbt_switch.yml"""
+    init_config()
+
+
+@cli.command()
+def add():
+    """Add a new project host and project_id"""
+    add_user_config_input("add")
+
+
+@cli.command("list")
+def list_projects_cmd():
+    """List all available projects"""
+    list_projects()
+
+
+@cli.command()
+def delete():
+    """Delete a project entry"""
+    delete_user_config_input("delete")
+
+
+@cli.command()
+@click.option("--host", is_flag=True, help="Update project host")
+@click.option("--project-id", is_flag=True, help="Update project ID")
+def update(host, project_id):
+    """Update project host or project_id"""
+    if host and project_id:
+        logger.error(
+            "Cannot update both host and project-id at the same time. Choose one."
+        )
         return
-
-    if args.command == "init":
-        init_config()
-
-    if args.command == "list":
-        list_projects()
-        return
-
-    if args.command == "add":
-        add_user_config_input(args.command)
-
-    if args.command == "delete":
-        delete_user_config_input(args.command)
-
-    if args.command == "update":
-        if args.host:
-            update_user_config_input("host")
-        elif args.project_id:
-            update_user_config_input("project_id")
-        else:
-            logger.warn("Please specify --host or --project-id")
+    elif host:
+        update_user_config_input("host")
+    elif project_id:
+        update_user_config_input("project_id")
+    else:
+        logger.error("Must specify either --host or --project-id")
+        click.echo("Use 'dbt-switch update --help' for more information.")

--- a/src/dbt_switch/main.py
+++ b/src/dbt_switch/main.py
@@ -2,11 +2,11 @@
 Main entry point for dbt-switch.
 """
 
-from dbt_switch.cli.parser import arg_parser
+from dbt_switch.cli.parser import cli
 
 
 def main():
-    arg_parser()
+    cli()
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 2
 requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -18,6 +22,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
 ]
 
 [[package]]
@@ -131,9 +165,11 @@ toml = [
 
 [[package]]
 name = "dbt-switch"
-version = "0.2.2"
-source = { virtual = "." }
+version = "0.2.3"
+source = { editable = "." }
 dependencies = [
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
@@ -149,6 +185,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.1.8" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pyyaml", specifier = ">=6.0.2" },
 ]


### PR DESCRIPTION
# Summary
Closes #15 

# Details
- Simple refactor that gives the following benefits:
  - Declarative code for CLI that allows for better devex/maintainability (argparse was imperative and needs manual control of state)
  - Future CLI-specific features will be easier to develop
- Trade-off is a new added dependency 
- Auto-complete needs more user config, but IS possible. I think another issue should be open to have autocomplete when searching for projects or commands (?)
 - Refactor tests